### PR TITLE
Remove outdated workaround from P03

### DIFF
--- a/prompts/P03.md
+++ b/prompts/P03.md
@@ -10,9 +10,6 @@ Write a program to help a user calculate percentages. The program should take tw
 >>> 
 ```
 
-Some students have reported that when trying to run the POTD3 test file on their personal computers they are getting an error: "subprocess.CalledProcessError: Command '['python3', 'p03_percent.py', "
-
-While the test scripts should work fine on the lab computers and during grading, it's easy to fix for working on your personal computer: change 'Python3' to 'Python' in the test script on line 7. 
 
 ## Other Practice Problems
 


### PR DESCRIPTION
P03 suggests changing the call to `python3` in the test file to `python` if it fails, as on some (Windows?) systems `python` is the name of the Python interpreter. This seems to be outdated advice, as the test file has an [`except` case ](https://github.com/w25-csci141/POTD/blob/9eeb7f2843fcea81cd65e6164b47383954b39ece/skel/P03_percent_test.py#L12)that tries `python` if `python3` fails. This PR removes that suggestion.